### PR TITLE
feat: Perfil do usuário

### DIFF
--- a/src/api/profile.ts
+++ b/src/api/profile.ts
@@ -1,0 +1,17 @@
+import { BrowserHeaders } from 'browser-headers'
+
+import { authServiceClient } from '@/lib/api'
+
+export async function profile() {
+  const token = localStorage.getItem('accessToken')
+
+  if (!token) return
+
+  const metadata = new BrowserHeaders({
+    authorization: `Bearer ${token}`,
+  })
+
+  const response = await authServiceClient.me({}, metadata)
+
+  return response
+}

--- a/src/components/account-menu.tsx
+++ b/src/components/account-menu.tsx
@@ -1,5 +1,7 @@
+import { useQuery } from '@tanstack/react-query'
 import { ChevronDown, LogOut, Moon, Sun } from 'lucide-react'
 
+import { profile } from '@/api/profile'
 import { useTheme } from '@/components/theme/theme-provider'
 import { Button } from '@/components/ui/button'
 import {
@@ -17,7 +19,11 @@ import { useSignOut } from '@/hooks/auth'
 export function AccountMenu() {
   const { theme, setTheme } = useTheme()
   const { signOutFn, isSigningOut } = useSignOut()
-  const isLoadingUser = false
+
+  const { data: user, isLoading } = useQuery({
+    queryKey: ['me'],
+    queryFn: profile,
+  })
 
   return (
     <Sheet>
@@ -34,15 +40,17 @@ export function AccountMenu() {
 
         <DropdownMenuContent align="end" className="w-56">
           <DropdownMenuLabel className="flex flex-col">
-            {isLoadingUser ? (
+            {isLoading ? (
               <div className="space-y-1.5">
                 <Skeleton className="h-4 w-32" />
                 <Skeleton className="h-3 w-24" />
               </div>
             ) : (
               <>
-                <span>Usuário</span>
-                <span className="font-normal text-muted-foreground">RA</span>
+                <span>{user?.name}</span>
+                <span className="font-normal text-muted-foreground">
+                  {user?.email}
+                </span>
               </>
             )}
           </DropdownMenuLabel>

--- a/src/routes/auth-guard.tsx
+++ b/src/routes/auth-guard.tsx
@@ -1,9 +1,8 @@
 import { useQuery } from '@tanstack/react-query'
-import { BrowserHeaders } from 'browser-headers'
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { authServiceClient } from '@/lib/api'
+import { profile } from '@/api/profile'
 
 interface AuthGuardProps {
   children: React.ReactNode
@@ -18,26 +17,7 @@ export function AuthGuard({ children }: AuthGuardProps) {
     isLoading,
   } = useQuery({
     queryKey: ['me'],
-    queryFn: async () => {
-      const token = localStorage.getItem('accessToken')
-
-      if (!token) {
-        throw new Error('No token found')
-      }
-
-      try {
-        const metadata = new BrowserHeaders({
-          authorization: `Bearer ${token}`,
-        })
-
-        const response = await authServiceClient.me({}, metadata)
-
-        return response
-      } catch (error) {
-        localStorage.removeItem('accessToken')
-        throw error
-      }
-    },
+    queryFn: profile,
     retry: false,
   })
 


### PR DESCRIPTION
 - Consumir rota `me` para retorno dos dados do usuário atualmente logado.

![image](https://github.com/user-attachments/assets/69a56646-b3da-43de-8390-1edb21028ad3)
