### PR TITLE
Remover IP fixo do backend

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -130,7 +130,7 @@ export class GrpcImpl {
   }
 }
 
-export const API_URL = `${window.location.protocol}//177.155.113.189:19080` // `https://${window.location.host}/api`
+export const API_URL = `${window.location.protocol}//${window.location.host}/api` // `https://${window.location.host}/api`
 
 export const grpcImpl = new GrpcImpl(API_URL, {
   transport: grpc.XhrTransport({


### PR DESCRIPTION
Havia sido feita uma tentativa de fazer funcionar o deploy no netlify com o backend hospedado na minha casa, mas problemas de SSL e CORS não colaboraram com a situação.

Remove o IP fixo do projeto, já que o deploy do netlify não foi bem-sucedido.

Para realizar o deploy da aplicação, utilizar o deploy recomendado conforme [documentação do backend](https://github.com/Squad-Maker/squad-maker-backend/blob/main/docs/deploy.md).
